### PR TITLE
Ensure that any RecordJob clears active db connections

### DIFF
--- a/lib/quebert/async_sender/active_record.rb
+++ b/lib/quebert/async_sender/active_record.rb
@@ -6,7 +6,7 @@ module Quebert
         def perform(record, meth, *args)
           record.send(meth, *args)
         ensure
-          ActiveRecord::Base.clear_active_connections!
+          ::ActiveRecord::Base.clear_active_connections!
         end
       end
 


### PR DESCRIPTION
This ensures that after performing a ActiveRecord job any active
connections are put back in ActiveRecord's connection pool for the
next RecordJob that comes along.
