### PR TITLE
Add Beanstalk job event hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Quebert.config.from_hash(Rails.application.config.quebert)
 Quebert.config.logger = Rails.logger
 ```
 
-### Job & Worker hooks
+### Global Job hooks
 
 Quebert has support for providing custom hooks to be called before, after & around your jobs are being run.
 A common example is making sure that any active ActiveRecord database connections are put back on the connection pool after a job is done:
@@ -116,6 +116,22 @@ Quebert.config.around_job do |job|
   # once before & once after a job is performed
 end
 ```
+
+### Beanstalk Job hooks
+
+Jobs can define their own business logic that will get called surrounding Beanstalk events:
+
+```ruby
+class FooJob < Quebert::Job
+  def around_bury
+    # custom pre-bury code
+    yield
+    # custom post-bury code
+  end
+end
+```
+
+Supported Beanstalk event hooks: `around_bury`, `around_release`, `around_delete`
 
 ### Async sender
 

--- a/lib/quebert/job.rb
+++ b/lib/quebert/job.rb
@@ -89,6 +89,21 @@ module Quebert
       @backend || Quebert.configuration.backend
     end
 
+    # Event hook that can be overridden
+    def around_bury
+      yield
+    end
+
+    # Event hook that can be overridden
+    def around_release
+      yield
+    end
+
+    # Event hook that can be overridden
+    def around_delete
+      yield
+    end
+
   protected
     def delete!
       raise Delete


### PR DESCRIPTION
Provides a way for jobs to add their own business logic that will get called surrounding Beanstalk events.

Jobs can define their own hooks like:

```rb
def around_bury
  # custom pre-bury code
  yield
  # custom post-bury code
end
```

I'm adding this feature because jobs with Poll Everywhere's `WithJobStatus` (which might eventually be extracted into a [resque-status](https://github.com/quirkey/resque-status) style library) do not know when they are buried and therefore cannot update their status to failed.

TODO: Update README and add tests pending PR approval.