### PR TITLE
Set low priority constant to valid Beanstalk priority value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+* Fix bug with low priority constant value
+
 ## 3.2.0
 
 * Add support for Beanstalk event hooks (#22)

--- a/lib/quebert/job.rb
+++ b/lib/quebert/job.rb
@@ -10,7 +10,7 @@ module Quebert
 
     # Prioritize Quebert jobs as specified in https://github.com/kr/beanstalkd/blob/master/doc/protocol.txt.
     class Priority
-      LOW     = 2**32
+      LOW     = 2**32 - 1
       MEDIUM  = LOW / 2
       HIGH    = 0
     end

--- a/lib/quebert/version.rb
+++ b/lib/quebert/version.rb
@@ -1,3 +1,3 @@
 module Quebert
-  VERSION = "3.2.0"
+  VERSION = "3.2.1"
 end

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -42,11 +42,11 @@ describe Quebert::Job do
   end
 
   describe "Quebert::Job::Priority" do
-    it "should have LOW priority of 4294967296" do
-      expect(Quebert::Job::Priority::LOW).to eql(4294967296)
+    it "should have LOW priority of 4294967295" do
+      expect(Quebert::Job::Priority::LOW).to eql(4294967295)
     end
     it "should have MEDIUM priority of 2147483648" do
-      expect(Quebert::Job::Priority::MEDIUM).to eql(2147483648)
+      expect(Quebert::Job::Priority::MEDIUM).to eql(2147483647)
     end
     it "should have HIGH priority of 0" do
       expect(Quebert::Job::Priority::HIGH).to eql(0)


### PR DESCRIPTION
According to the [Beanstalk protocol](https://github.com/beanstalkd/beanstalkd/blob/master/doc/protocol.txt), the least urgent priority is 4,294,967,295. This is a value less than 2<sup>32</sup>.

It appears that queueing a job with an invalid priority values will cause it to be queued with the highest priority.

```
require "beaneater"

beanstalk = Beaneater.new('localhost:11300')
tube = beanstalk.tubes["test"]
tube.put '{ "key" : "foo" }', :pri => 2**32

while tube.peek(:ready)
  job = tube.reserve
  puts "job pri is #{job.pri}"
  job.delete
end

beanstalk.close
```

The script above will output `job pri is 0`, while setting the priority to 2<sup>32</sup> - 1 will output `job pri is 4294967295`.