### PR TITLE
Remove job arguments from perform log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.2.5
-  - 2.3.1
-  - 2.4.1
+  - 2.4.3
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
 before_install:
   - curl -L https://github.com/kr/beanstalkd/archive/v1.9.tar.gz | tar xz -C /tmp
   - cd /tmp/beanstalkd-1.9/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.3.0
+
+* Remove job argument log output. Job authors are expected to use logs if they find them necessary for their job execution. However, the default behavior has changed to no longer support this by default.
+* Remove support for EOS/EOL ruby versions beyond 2.4.
+
 ## 3.2.1
 
 * Fix bug with low priority constant value

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 group :test do
   gem 'activerecord', '~> 4.0'
-  gem 'sqlite3-ruby'
+  gem 'sqlite3', '~> 1.3.6'
   gem 'rspec', '~> 3.5'
   gem 'rb-fsevent'
   gem 'pry'

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ There are two ways to enqueue jobs with Quebert: through the Job itself, provide
 ### Supported Ruby Versions
 
 Quebert officially is supported to run on the currently supported versions of MRI.
-This includes versions >= `2.2.5`. Have a look at the `.travis.yml` configuration file to see all Ruby versions we support.
+This includes versions >= `2.4.3`. Have a look at the `.travis.yml` configuration file to see all Ruby versions we support.
 
 ### Jobs
 

--- a/lib/quebert/controller/beanstalk.rb
+++ b/lib/quebert/controller/beanstalk.rb
@@ -22,7 +22,7 @@ module Quebert
       end
 
       def perform
-        logger.error(job) { "Performing #{job.class.name} with args #{job.args.inspect}" }
+        logger.error(job) { "Performing #{job.class.name}." }
         logger.error(job) { "Beanstalk Job Stats: #{beanstalk_job.stats.inspect}" }
 
         result = false

--- a/lib/quebert/version.rb
+++ b/lib/quebert/version.rb
@@ -1,3 +1,3 @@
 module Quebert
-  VERSION = "3.2.1"
+  VERSION = "3.3.0"
 end


### PR DESCRIPTION
In general, I think this actually needs more improvement. The logging on
the `perform` method seems to be very verbose and not super beneficial
in practice.

The actual reason why I culled the job arguments are simple.
Implementors of jobs may pass items like passwords, session tokens, and
other things to quebert for job processing as arguments to jobs.
Unfortuantely, this log entry guarantees that all of those arguments are
pushed to whatever logging system is in service. In many cases this is
internal, but in some caes, a user with a third party like Datadog may
accidentally send sensitive information to that third party.

I'm open to alternatives on this. In particular, I considered, but did
not implement something like a `quiet_perform` or changing the arguments
to perform to take a quiet argument as both seem like they would
introduce API breaking changes. Cutting off the debug output here would
make sense as any job that actually needs to send debug output can
easily do so when it executes. It leaves the decision up to the person
implementing the job, not implementing the job processor.